### PR TITLE
 fix makeInsertSql struct

### DIFF
--- a/Base.go
+++ b/Base.go
@@ -108,7 +108,9 @@ func makeKeysVarsValues(data interface{}) ([]string, []string, []interface{}) {
 				v = v.Elem()
 			}
 			keys = append(keys, dataType.Field(i).Name)
-			if v.Kind() == reflect.String && []byte(v.String())[0] == ':' {
+
+
+			if v.Kind() == reflect.String && len(v.String()) > 0 && []byte(v.String())[0] == ':' {
 				vars = append(vars, string([]byte(v.String())[1:]))
 			} else {
 				vars = append(vars, "?")

--- a/Base.go
+++ b/Base.go
@@ -108,9 +108,7 @@ func makeKeysVarsValues(data interface{}) ([]string, []string, []interface{}) {
 				v = v.Elem()
 			}
 			keys = append(keys, dataType.Field(i).Name)
-
-
-			if v.Kind() == reflect.String && len(v.String()) > 0 && []byte(v.String())[0] == ':' {
+			if v.Kind() == reflect.String && v.Len() > 0 && []byte(v.String())[0] == ':' {
 				vars = append(vars, string([]byte(v.String())[1:]))
 			} else {
 				vars = append(vars, "?")

--- a/DB_test.go
+++ b/DB_test.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-
 	"github.com/ssgo/log"
 	"github.com/ssgo/u"
 	"strings"
@@ -29,18 +28,17 @@ type UserModel struct {
 	Salt       string
 }
 
-
 func TestMakeInsertSql(t *testing.T) {
 
 	user := &UserModel{
-		Name : "王二小",
-		UserStatus : 1, //正常,
-		Password : "2121asds",
-		Salt : "de312",
+		Name:       "王二小",
+		UserStatus: 1, //正常,
+		Password:   "2121asds",
+		Salt:       "de312",
 	}
 
 	requestSql, _ := makeInsertSql("table_name", user, false)
-    if requestSql != "insert into `table_name` (`Id`,`Name`,`Phone`,`Password`,`UserStatus`,`Owner`,`Salt`) values (?,?,?,?,?,?,?)" {
+	if requestSql != "insert into `table_name` (`Id`,`Name`,`Phone`,`Password`,`UserStatus`,`Owner`,`Salt`) values (?,?,?,?,?,?,?)" {
 		t.Error("MakeInsertSql requestSql error ")
 	}
 }

--- a/DB_test.go
+++ b/DB_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+
 	"github.com/ssgo/log"
 	"github.com/ssgo/u"
 	"strings"
@@ -16,6 +17,32 @@ type userInfo struct {
 	Phone string
 	Email string
 	Time  string
+}
+
+type UserModel struct {
+	Id         int
+	Name       string
+	Phone      string
+	Password   string
+	UserStatus int
+	Owner      int
+	Salt       string
+}
+
+
+func TestMakeInsertSql(t *testing.T) {
+
+	user := &UserModel{
+		Name : "王二小",
+		UserStatus : 1, //正常,
+		Password : "2121asds",
+		Salt : "de312",
+	}
+
+	requestSql, _ := makeInsertSql("table_name", user, false)
+    if requestSql != "insert into `table_name` (`Id`,`Name`,`Phone`,`Password`,`UserStatus`,`Owner`,`Salt`) values (?,?,?,?,?,?,?)" {
+		t.Error("MakeInsertSql requestSql error ")
+	}
 }
 
 func TestBaseSelect(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/go-sql-driver/mysql v1.4.1
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/ssgo/config v0.2.0
 	github.com/ssgo/log v0.2.0
 	github.com/ssgo/u v0.2.0


### PR DESCRIPTION
--- FAIL: TestDB_makeInsertSql (0.00s)
panic: runtime error: index out of range [recovered]
	panic: runtime error: index out of range

goroutine 34 [running]:
testing.tRunner.func1(0xc000130100)
	/usr/local/Cellar/go/1.12.6/libexec/src/testing/testing.go:830 +0x392
panic(0x12de2e0, 0x15693f0)
	/usr/local/Cellar/go/1.12.6/libexec/src/runtime/panic.go:522 +0x1b5
github.com/ssgo/db.makeKeysVarsValues(0x12bb000, 0xc0000de3c0, 0x203000, 0x0, 0x1551d86, 0x3b, 0xc000000539, 0x100d8b9, 0xc0001386c8, 0x100d8b9, ...)
	/Users/github/db/Base.go:111 +0x124a
github.com/ssgo/db.makeInsertSql(0x132d631, 0xa, 0x12bb000, 0xc0000de3c0, 0x109d4000, 0x94f3109d40a9, 0x100000001, 0xc000138770, 0x104dbe8, 0x94f3109d40a9)
	/Users/github/db/Base.go:68 +0x50
github.com/ssgo/db.TestDB_makeInsertSql(0xc000130100)
	/Users/github/db/DB_test.go:52 +0x12c
testing.tRunner(0xc000130100, 0x133ee10)
	/usr/local/Cellar/go/1.12.6/libexec/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
	/usr/local/Cellar/go/1.12.6/libexec/src/testing/testing.go:916 +0x35a
exit status 2
